### PR TITLE
Issue: [MOSC-124]

### DIFF
--- a/src/main/java/gov/sgpr/fgv/osc/portalosc/map/client/components/MatrixWidget.java
+++ b/src/main/java/gov/sgpr/fgv/osc/portalosc/map/client/components/MatrixWidget.java
@@ -68,7 +68,7 @@ public class MatrixWidget extends Composite {
 			indicatorListBox.addItem(ind);
 		}
 		int count = places.length > 50 ? 50 : places.length;
-		indicatorListBox.setVisibleItemCount(count);
+		indicatorListBox.setVisibleItemCount(count+1);
 		String listHeight = (indicators.size() * 30) + "px";
 		indicatorListBox.setHeight(listHeight);
 		grid.setWidget(0, 0, indicatorListBox.asWidget());


### PR DESCRIPTION
Subject: Normalizar o tamanho das opções na matriz de indicadores 
Detail: contador deve ser maior que 1 para o componente não criar um
dropdown de 1 item só